### PR TITLE
Fetch repositories full history

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
     - name: Install Nix
       uses: cachix/install-nix-action@v12
       with:


### PR DESCRIPTION
Github actions for build only pulls the head commit (since v2) this causes all articles' commit links to point to a wrong commit