### PR TITLE
fix: render heading as such in pandoc

### DIFF
--- a/src/posts/guides/nix-shells.md
+++ b/src/posts/guides/nix-shells.md
@@ -416,6 +416,7 @@ nix develop --impure --expr "with import <nixpkgs> {}; pkgs.mkShell { packages =
 ```
 
 Both approaches work to some degree but are clunky (i.e. *not improving UX as promised*) and rely on the supposed-to-be-superseded channels.
+
 ## The second-hardest problem
 
 Picking up the confusion mentioned in the beginning, there is another problem with `nix shell`... naming.


### PR DESCRIPTION
See https://blog.ysndr.de/posts/guides/2021-12-01-nix-shells/#workarounds currently has a broken heading after this section.

I think this is a difference in behaviour of pandoc vs github's markdown rendering. It would be best if you can configure your site generator to just use the github format.

Thanks for writing the post by the way 😄 